### PR TITLE
Add MeanFlow variant for time-series signals

### DIFF
--- a/Vibration/meanflow_ts.py
+++ b/Vibration/meanflow_ts.py
@@ -1,0 +1,113 @@
+import torch
+import torch.nn.functional as F
+from functools import partial
+import numpy as np
+
+
+def stopgrad(x):
+    return x.detach()
+
+
+def adaptive_l2_loss(error, gamma=0.5, c=1e-3):
+    delta_sq = torch.mean(error ** 2, dim=(1, 2))
+    p = 1.0 - gamma
+    w = 1.0 / (delta_sq + c).pow(p)
+    loss = delta_sq
+    return (stopgrad(w) * loss).mean()
+
+
+class Normalizer:
+    def __init__(self, mode='minmax', mean=None, std=None):
+        assert mode in ['minmax', 'mean_std']
+        self.mode = mode
+        if mode == 'mean_std':
+            if mean is None or std is None:
+                raise ValueError('mean and std must be provided for mean_std mode')
+            self.mean = torch.tensor(mean).view(-1, 1)
+            self.std = torch.tensor(std).view(-1, 1)
+
+    @classmethod
+    def from_list(cls, config):
+        mode, mean, std = config
+        return cls(mode, mean, std)
+
+    def norm(self, x):
+        if self.mode == 'minmax':
+            return x * 2 - 1
+        else:
+            return (x - self.mean.to(x.device)) / self.std.to(x.device)
+
+    def unnorm(self, x):
+        if self.mode == 'minmax':
+            x = x.clip(-1, 1)
+            return (x + 1) * 0.5
+        else:
+            return x * self.std.to(x.device) + self.mean.to(x.device)
+
+
+class MeanFlowTS:
+    def __init__(self, channels=2, seq_len=1024, normalizer=['minmax', None, None],
+                 flow_ratio=0.5, time_dist=['lognorm', -0.4, 1.0]):
+        self.channels = channels
+        self.seq_len = seq_len
+        self.normer = Normalizer.from_list(normalizer)
+        self.flow_ratio = flow_ratio
+        self.time_dist = time_dist
+        self.jvp_fn = torch.autograd.functional.jvp
+
+    def sample_t_r(self, batch_size, device):
+        if self.time_dist[0] == 'uniform':
+            samples = np.random.rand(batch_size, 2).astype(np.float32)
+        else:
+            mu, sigma = self.time_dist[-2], self.time_dist[-1]
+            normal_samples = np.random.randn(batch_size, 2).astype(np.float32) * sigma + mu
+            samples = 1 / (1 + np.exp(-normal_samples))
+
+        t_np = np.maximum(samples[:, 0], samples[:, 1])
+        r_np = np.minimum(samples[:, 0], samples[:, 1])
+
+        num_selected = int(self.flow_ratio * batch_size)
+        indices = np.random.permutation(batch_size)[:num_selected]
+        r_np[indices] = t_np[indices]
+
+        t = torch.tensor(t_np, device=device)
+        r = torch.tensor(r_np, device=device)
+        return t, r
+
+    def loss(self, model, x):
+        batch_size = x.shape[0]
+        device = x.device
+        t, r = self.sample_t_r(batch_size, device)
+        t_ = t.view(-1, 1, 1)
+        r_ = r.view(-1, 1, 1)
+        e = torch.randn_like(x)
+        x = self.normer.norm(x)
+        z = (1 - t_) * x + t_ * e
+        v = e - x
+        model_partial = partial(model, y=None)
+        jvp_args = (
+            lambda z, t, r: model_partial(z, t, r),
+            (z, t, r),
+            (v, torch.ones_like(t), torch.zeros_like(r)),
+        )
+        u, dudt = self.jvp_fn(*jvp_args, create_graph=True)
+        u_tgt = v - (t_ - r_) * dudt
+        error = u - stopgrad(u_tgt)
+        loss = adaptive_l2_loss(error)
+        mse_val = (stopgrad(error) ** 2).mean()
+        return loss, mse_val
+
+    @torch.no_grad()
+    def sample(self, model, n_samples=1, sample_steps=5, device='cuda'):
+        model.eval()
+        z = torch.randn(n_samples, self.channels, self.seq_len, device=device)
+        t_vals = torch.linspace(1.0, 0.0, sample_steps + 1, device=device)
+        for i in range(sample_steps):
+            t = torch.full((z.size(0),), t_vals[i], device=device)
+            r = torch.full((z.size(0),), t_vals[i+1], device=device)
+            t_ = t.view(-1,1,1)
+            r_ = r.view(-1,1,1)
+            v = model(z, t, r, None)
+            z = z - (t_-r_) * v
+        z = self.normer.unnorm(z)
+        return z

--- a/Vibration/signal_dataset.py
+++ b/Vibration/signal_dataset.py
@@ -1,0 +1,23 @@
+import torch
+from torch.utils.data import Dataset
+import numpy as np
+
+class HarmonicDataset(Dataset):
+    """Generate multi-dimensional harmonic sequences."""
+    def __init__(self, length=1024, n_samples=10000, freq_range=(5,50), n_channels=2, sample_rate=200):
+        self.length = length
+        self.n_samples = n_samples
+        self.freq_range = freq_range
+        self.n_channels = n_channels
+        self.sample_rate = sample_rate
+
+    def __len__(self):
+        return self.n_samples
+
+    def __getitem__(self, idx):
+        t = np.arange(self.length) / self.sample_rate
+        freqs = np.random.uniform(*self.freq_range, size=self.n_channels)
+        phases = np.random.uniform(0, 2*np.pi, size=self.n_channels)
+        signal = [np.sin(2*np.pi*f*t + p) for f,p in zip(freqs, phases)]
+        signal = np.stack(signal, axis=0).astype(np.float32)
+        return torch.from_numpy(signal)

--- a/Vibration/train_ts.py
+++ b/Vibration/train_ts.py
@@ -1,0 +1,29 @@
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from ts_dit import TSDiT
+from meanflow_ts import MeanFlowTS
+from signal_dataset import HarmonicDataset
+
+
+def train():
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    dataset = HarmonicDataset(length=1024, n_samples=10000, n_channels=2)
+    dataloader = DataLoader(dataset, batch_size=32, shuffle=True)
+    model = TSDiT(input_size=1024, patch_size=16, in_channels=2, dim=256, depth=8).to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    meanflow = MeanFlowTS(channels=2, seq_len=1024)
+
+    for step in tqdm(range(1000)):
+        x = next(iter(dataloader)).to(device)
+        loss, mse = meanflow.loss(model, x)
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        if step % 100 == 0:
+            print(f"step {step} loss {loss.item():.4f} mse {mse.item():.4f}")
+    torch.save(model.state_dict(), 'ts_model.pt')
+
+
+if __name__ == '__main__':
+    train()

--- a/Vibration/ts_dit.py
+++ b/Vibration/ts_dit.py
@@ -1,0 +1,145 @@
+import torch
+import torch.nn as nn
+import math
+import numpy as np
+import torch.nn.functional as F
+from einops import repeat
+
+
+def modulate(x, scale, shift):
+    return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+
+
+class PatchEmbed1D(nn.Module):
+    def __init__(self, input_size, patch_size, in_channels, embed_dim):
+        super().__init__()
+        self.proj = nn.Conv1d(in_channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+        self.num_patches = input_size // patch_size
+        self.patch_size = patch_size
+
+    def forward(self, x):
+        x = self.proj(x)  # N, dim, T'
+        x = x.transpose(1, 2)  # N, T', dim
+        return x
+
+
+class TimestepEmbedder(nn.Module):
+    def __init__(self, dim, nfreq=256):
+        super().__init__()
+        self.mlp = nn.Sequential(nn.Linear(nfreq, dim), nn.SiLU(), nn.Linear(dim, dim))
+        self.nfreq = nfreq
+
+    @staticmethod
+    def timestep_embedding(t, dim, max_period=10000):
+        half = dim // 2
+        freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half).to(t.device)
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+        return embedding
+
+    def forward(self, t):
+        t = t * 1000
+        t_freq = self.timestep_embedding(t, self.nfreq)
+        return self.mlp(t_freq)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.scale = dim ** 0.5
+        self.g = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        return F.normalize(x, dim=-1) * self.scale * self.g
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim, num_heads, mlp_ratio=4.0):
+        super().__init__()
+        self.norm1 = RMSNorm(dim)
+        self.attn = nn.MultiheadAttention(dim, num_heads)
+        self.norm2 = RMSNorm(dim)
+        mlp_dim = int(dim * mlp_ratio)
+        self.mlp = nn.Sequential(nn.Linear(dim, mlp_dim), nn.GELU(), nn.Linear(mlp_dim, dim))
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(dim, 6 * dim))
+
+    def forward(self, x, c):
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaLN_modulation(c).chunk(6, dim=-1)
+        x = x + gate_msa.unsqueeze(1) * self.attn(modulate(self.norm1(x), scale_msa, shift_msa).transpose(0,1),
+                                                  modulate(self.norm1(x), scale_msa, shift_msa).transpose(0,1),
+                                                  modulate(self.norm1(x), scale_msa, shift_msa).transpose(0,1))[0].transpose(0,1)
+        x = x + gate_mlp.unsqueeze(1) * self.mlp(modulate(self.norm2(x), scale_mlp, shift_mlp))
+        return x
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, dim, patch_size, out_dim):
+        super().__init__()
+        self.norm_final = RMSNorm(dim)
+        self.linear = nn.Linear(dim, patch_size * out_dim)
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(dim, 2 * dim))
+        self.patch_size = patch_size
+        self.out_dim = out_dim
+
+    def forward(self, x, c):
+        shift, scale = self.adaLN_modulation(c).chunk(2, dim=-1)
+        x = modulate(self.norm_final(x), shift, scale)
+        x = self.linear(x)
+        return x
+
+
+class TSDiT(nn.Module):
+    def __init__(self, input_size=1024, patch_size=16, in_channels=2, dim=256, depth=8, num_heads=8, num_classes=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = in_channels
+        self.patch_size = patch_size
+        self.num_classes = num_classes
+
+        self.x_embedder = PatchEmbed1D(input_size, patch_size, in_channels, dim)
+        self.t_embedder = TimestepEmbedder(dim)
+        self.r_embedder = TimestepEmbedder(dim)
+        self.use_cond = num_classes is not None
+        self.y_embedder = nn.Embedding(num_classes + 1, dim) if self.use_cond else None
+
+        self.pos_embed = nn.Parameter(torch.zeros(1, self.x_embedder.num_patches, dim), requires_grad=True)
+
+        self.blocks = nn.ModuleList([DiTBlock(dim, num_heads) for _ in range(depth)])
+        self.final_layer = FinalLayer(dim, patch_size, self.out_channels)
+
+        self.initialize_weights()
+
+    def initialize_weights(self):
+        def _basic_init(m):
+            if isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+        self.apply(_basic_init)
+        if self.y_embedder is not None:
+            nn.init.normal_(self.y_embedder.weight, std=0.02)
+        nn.init.constant_(self.final_layer.linear.weight, 0)
+        nn.init.constant_(self.final_layer.linear.bias, 0)
+
+    def unpatchify(self, x):
+        N, T, D = x.shape
+        x = x.reshape(N, T, self.patch_size, self.out_channels)
+        x = x.permute(0,3,1,2).reshape(N, self.out_channels, T*self.patch_size)
+        return x
+
+    def forward(self, x, t, r, y=None):
+        L = x.shape[-1]
+        x = self.x_embedder(x) + self.pos_embed
+        t = self.t_embedder(t)
+        r = self.r_embedder(r)
+        c = t + r
+        if self.use_cond:
+            y = self.y_embedder(y)
+            c = c + y
+        for block in self.blocks:
+            x = block(x, c)
+        x = self.final_layer(x, c)
+        x = self.unpatchify(x)
+        return x


### PR DESCRIPTION
## Summary
- add an example dataset generator for harmonic sequences
- implement `TSDiT` transformer for 1D time-series signals
- create `MeanFlowTS` variant for sequential data
- provide a simple training script in `Vibration/train_ts.py`

## Testing
- `python -m py_compile Vibration/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c96e9ac2c8323a9c72283e1b74ae3