### PR TITLE
Add 1D vibration example

### DIFF
--- a/Vibration/harmonic_dataset.py
+++ b/Vibration/harmonic_dataset.py
@@ -1,0 +1,29 @@
+import torch
+from torch.utils.data import Dataset
+import numpy as np
+
+class HarmonicDataset(Dataset):
+    """Generate multi-dimensional harmonic signals."""
+
+    def __init__(self, num_samples=1000, seq_len=1024, channels=2,
+                 num_harmonics=3, freq_range=(50, 500), sample_rate=2000):
+        self.num_samples = num_samples
+        self.seq_len = seq_len
+        self.channels = channels
+        self.num_harmonics = num_harmonics
+        self.freq_range = freq_range
+        self.sample_rate = sample_rate
+        self.t = torch.linspace(0, seq_len / sample_rate, seq_len)
+
+    def __len__(self):
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        signal = torch.zeros(self.channels, self.seq_len)
+        for c in range(self.channels):
+            for _ in range(self.num_harmonics):
+                freq = np.random.uniform(*self.freq_range)
+                phase = np.random.uniform(0, 2 * np.pi)
+                amp = np.random.uniform(0.5, 1.0)
+                signal[c] += amp * torch.sin(2 * np.pi * freq * self.t + phase)
+        return signal

--- a/Vibration/meanflow_1d.py
+++ b/Vibration/meanflow_1d.py
@@ -1,0 +1,249 @@
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from functools import partial
+import numpy as np
+
+
+class Normalizer:
+    """Simple data normalizer for both images and 1D signals."""
+
+    def __init__(self, mode='minmax', mean=None, std=None):
+        assert mode in ['minmax', 'mean_std'], "mode must be 'minmax' or 'mean_std'"
+        self.mode = mode
+
+        if mode == 'mean_std':
+            if mean is None or std is None:
+                raise ValueError("mean and std must be provided for 'mean_std' mode")
+            # store mean/std as 1D tensors, broadcast later depending on x.dim()
+            self.mean = torch.tensor(mean)
+            self.std = torch.tensor(std)
+
+    @classmethod
+    def from_list(cls, config):
+        """
+        config: [mode, mean, std]
+        """
+        mode, mean, std = config
+        return cls(mode, mean, std)
+
+    def norm(self, x):
+        if self.mode == 'minmax':
+            return x * 2 - 1
+        elif self.mode == 'mean_std':
+            dims = x.dim() - 1
+            shape = [self.mean.shape[0]] + [1] * dims
+            mean = self.mean.view(*shape).to(x.device)
+            std = self.std.view(*shape).to(x.device)
+            return (x - mean) / std
+
+    def unnorm(self, x):
+        if self.mode == 'minmax':
+            x = x.clip(-1, 1)
+            return (x + 1) * 0.5
+        elif self.mode == 'mean_std':
+            dims = x.dim() - 1
+            shape = [self.mean.shape[0]] + [1] * dims
+            mean = self.mean.view(*shape).to(x.device)
+            std = self.std.view(*shape).to(x.device)
+            return x * std + mean
+
+
+def stopgrad(x):
+    return x.detach()
+
+
+def adaptive_l2_loss(error, gamma=0.5, c=1e-3):
+    """
+    Adaptive L2 loss: sg(w) * ||Δ||_2^2, where w = 1 / (||Δ||^2 + c)^p, p = 1 - γ
+    Args:
+        error: Tensor of shape (B, C, W, H)
+        gamma: Power used in original ||Δ||^{2γ} loss
+        c: Small constant for stability
+    Returns:
+        Scalar loss
+    """
+    dims = tuple(range(1, error.dim()))
+    delta_sq = torch.mean(error ** 2, dim=dims, keepdim=False)
+    p = 1.0 - gamma
+    w = 1.0 / (delta_sq + c).pow(p)
+    loss = delta_sq  # ||Δ||^2
+    return (stopgrad(w) * loss).mean()
+
+
+class MeanFlow1D:
+    def __init__(
+        self,
+        channels=1,
+        signal_length=1024,
+        num_classes=10,
+        normalizer=['minmax', None, None],
+        # mean flow settings
+        flow_ratio=0.50,
+        # time distribution, mu, sigma
+        time_dist=['lognorm', -0.4, 1.0],
+        cfg_ratio=0.10,
+        # set scale as none to disable CFG distill
+        cfg_scale=2.0,
+        # experimental
+        cfg_uncond='u',
+        jvp_api='autograd',
+    ):
+        super().__init__()
+        self.channels = channels
+        self.signal_length = signal_length
+        self.num_classes = num_classes
+        self.use_cond = num_classes is not None
+
+        self.normer = Normalizer.from_list(normalizer)
+
+        self.flow_ratio = flow_ratio
+        self.time_dist = time_dist
+        self.cfg_ratio = cfg_ratio
+        self.w = cfg_scale
+
+        self.cfg_uncond = cfg_uncond
+        self.jvp_api = jvp_api
+
+        assert jvp_api in ['funtorch', 'autograd'], "jvp_api must be 'funtorch' or 'autograd'"
+        if jvp_api == 'funtorch':
+            self.jvp_fn = torch.func.jvp
+            self.create_graph = False
+        elif jvp_api == 'autograd':
+            self.jvp_fn = torch.autograd.functional.jvp
+            self.create_graph = True
+
+    # fix: r should be always not larger than t
+    def sample_t_r(self, batch_size, device):
+        if self.time_dist[0] == 'uniform':
+            samples = np.random.rand(batch_size, 2).astype(np.float32)
+
+        elif self.time_dist[0] == 'lognorm':
+            mu, sigma = self.time_dist[-2], self.time_dist[-1]
+            normal_samples = np.random.randn(batch_size, 2).astype(np.float32) * sigma + mu
+            samples = 1 / (1 + np.exp(-normal_samples))  # Apply sigmoid
+
+        # Assign t = max, r = min, for each pair
+        t_np = np.maximum(samples[:, 0], samples[:, 1])
+        r_np = np.minimum(samples[:, 0], samples[:, 1])
+
+        num_selected = int(self.flow_ratio * batch_size)
+        indices = np.random.permutation(batch_size)[:num_selected]
+        r_np[indices] = t_np[indices]
+
+        t = torch.tensor(t_np, device=device)
+        r = torch.tensor(r_np, device=device)
+        return t, r
+
+    def loss(self, model, x, c=None):
+        batch_size = x.shape[0]
+        device = x.device
+
+        t, r = self.sample_t_r(batch_size, device)
+
+        expand_shape = [batch_size] + [1] * (x.dim() - 1)
+        t_ = t.view(*expand_shape).detach().clone()
+        r_ = r.view(*expand_shape).detach().clone()
+
+        e = torch.randn_like(x)
+        x = self.normer.norm(x)
+
+        z = (1 - t_) * x + t_ * e
+        v = e - x
+
+        if c is not None:
+            assert self.cfg_ratio is not None
+            uncond = torch.ones_like(c) * self.num_classes
+            cfg_mask = torch.rand_like(c.float()) < self.cfg_ratio
+            c = torch.where(cfg_mask, uncond, c)
+            if self.w is not None:
+                with torch.no_grad():
+                    u_t = model(z, t, t, uncond)
+                v_hat = self.w * v + (1 - self.w) * u_t
+                if self.cfg_uncond == 'v':
+                    # In the unconditional case, v = w * v + (1 - w) * u,
+                    # so if we're choosing to use 'v' for uncond settings, we can just keep v.
+                    # Apply this only to the unconditional samples indicated by cfg_mask.
+                    cfg_mask = cfg_mask.view(*expand_shape).bool()
+                    v_hat = torch.where(cfg_mask, v, v_hat)
+            else:
+                v_hat = v
+
+        # forward pass
+        # u = model(z, t, r, y=c)
+        model_partial = partial(model, y=c)
+        jvp_args = (
+            lambda z, t, r: model_partial(z, t, r),
+            (z, t, r),
+            (v_hat, torch.ones_like(t), torch.zeros_like(r)),
+        )
+
+        if self.create_graph:
+            u, dudt = self.jvp_fn(*jvp_args, create_graph=True)
+        else:
+            u, dudt = self.jvp_fn(*jvp_args)
+
+        u_tgt = v_hat - (t_ - r_) * dudt
+
+        error = u - stopgrad(u_tgt)
+        loss = adaptive_l2_loss(error)
+        # loss = F.mse_loss(u, stopgrad(u_tgt))
+
+        mse_val = (stopgrad(error) ** 2).mean()
+        return loss, mse_val
+
+    @torch.no_grad()
+    def sample_each_class(self, model, n_per_class, classes=None,
+                          sample_steps=5, device='cuda'):
+        model.eval()
+
+        if classes is None:
+            c = torch.arange(self.num_classes, device=device).repeat(n_per_class)
+        else:
+            c = torch.tensor(classes, device=device).repeat(n_per_class)
+
+        z = torch.randn(c.shape[0], self.channels,
+                        self.signal_length,
+                        device=device)
+
+        t_vals = torch.linspace(1.0, 0.0, sample_steps + 1, device=device)
+
+        # print(t_vals)
+
+        for i in range(sample_steps):
+            t = torch.full((z.size(0),), t_vals[i], device=device)
+            r = torch.full((z.size(0),), t_vals[i + 1], device=device)
+
+            # print(f"t: {t[0].item():.4f};  r: {r[0].item():.4f}")
+
+            expand_shape = [z.size(0)] + [1] * (z.dim() - 1)
+            t_ = t.view(*expand_shape).detach().clone()
+            r_ = r.view(*expand_shape).detach().clone()
+
+            v = model(z, t, r, c)
+            z = z - (t_-r_) * v
+
+        z = self.normer.unnorm(z)
+        return z
+
+    @torch.no_grad()
+    def sample(self, model, batch_size, sample_steps=5, device='cuda'):
+        """Unconditional sampling when no class labels are used."""
+        model.eval()
+
+        z = torch.randn(batch_size, self.channels, self.signal_length, device=device)
+        t_vals = torch.linspace(1.0, 0.0, sample_steps + 1, device=device)
+
+        for i in range(sample_steps):
+            t = torch.full((batch_size,), t_vals[i], device=device)
+            r = torch.full((batch_size,), t_vals[i + 1], device=device)
+
+            expand_shape = [batch_size] + [1] * (z.dim() - 1)
+            t_ = t.view(*expand_shape)
+            r_ = r.view(*expand_shape)
+
+            v = model(z, t, r, None)
+            z = z - (t_ - r_) * v
+
+        z = self.normer.unnorm(z)
+        return z

--- a/Vibration/model_1d.py
+++ b/Vibration/model_1d.py
@@ -1,0 +1,299 @@
+import torch
+import torch.nn as nn
+import numpy as np
+import math
+from timm.models.vision_transformer import Mlp, Attention
+import torch.nn.functional as F
+from einops import repeat, pack, unpack
+from torch.cuda.amp import autocast
+
+
+class PatchEmbed1D(nn.Module):
+    """1D convolutional patch embedding."""
+
+    def __init__(self, input_size, patch_size, in_channels, embed_dim):
+        super().__init__()
+        self.patch_size = patch_size
+        self.num_patches = input_size // patch_size
+        self.proj = nn.Conv1d(in_channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+
+    def forward(self, x):
+        # x: (N, C, L)
+        x = self.proj(x)  # (N, D, L/patch)
+        x = x.permute(0, 2, 1)  # (N, T, D)
+        return x
+
+
+def modulate(x, scale, shift):
+    return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+
+
+class TimestepEmbedder(nn.Module):
+    def __init__(self, dim, nfreq=256):
+        super().__init__()
+        self.mlp = nn.Sequential(nn.Linear(nfreq, dim), nn.SiLU(), nn.Linear(dim, dim))
+        self.nfreq = nfreq
+
+    @staticmethod
+    def timestep_embedding(t, dim, max_period=10000):
+        half_dim = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period)
+            * torch.arange(start=0, end=half_dim, dtype=torch.float32)
+            / half_dim
+        ).to(device=t.device)
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])], dim=-1
+            )
+        return embedding
+
+    def forward(self, t):
+        t = t*1000
+        t_freq = self.timestep_embedding(t, self.nfreq)
+        t_emb = self.mlp(t_freq)
+        return t_emb
+
+
+class LabelEmbedder(nn.Module):
+    def __init__(self, num_classes, dim):
+        super().__init__()
+        self.embedding = nn.Embedding(num_classes + 1, dim)
+        self.num_classes = num_classes
+
+    def forward(self, labels):
+        embeddings = self.embedding(labels)
+        return embeddings
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.scale = dim**0.5
+        self.g = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        return F.normalize(x, dim=-1) * self.scale * self.g
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim, num_heads, mlp_ratio=4.0):
+        super().__init__()
+        self.norm1 = RMSNorm(dim)
+        self.attn = Attention(dim, num_heads=num_heads, qkv_bias=True, qk_norm=True, norm_layer=RMSNorm)
+        # flasth attn can not be used with jvp
+        self.attn.fused_attn = False
+        self.norm2 = RMSNorm(dim)
+        mlp_dim = int(dim * mlp_ratio)
+        approx_gelu = lambda: nn.GELU(approximate="tanh")
+        self.mlp = Mlp(
+            in_features=dim, hidden_features=mlp_dim, act_layer=approx_gelu, drop=0
+        )
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(dim, 6 * dim))
+
+    def forward(self, x, c):
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            self.adaLN_modulation(c).chunk(6, dim=-1)
+        )
+        x = x + gate_msa.unsqueeze(1) * self.attn(
+            modulate(self.norm1(x), scale_msa, shift_msa)
+        )
+        x = x + gate_mlp.unsqueeze(1) * self.mlp(
+            modulate(self.norm2(x), scale_mlp, shift_mlp)
+        )
+        return x
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, dim, patch_size, out_dim):
+        super().__init__()
+        self.norm_final = RMSNorm(dim)
+        self.linear = nn.Linear(dim, patch_size * out_dim)
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(dim, 2 * dim))
+
+    def forward(self, x, c):
+        shift, scale = self.adaLN_modulation(c).chunk(2, dim=-1)
+        x = modulate(self.norm_final(x), shift, scale)
+        x = self.linear(x)
+        return x
+
+
+class MFDiT1D(nn.Module):
+    def __init__(
+        self,
+        input_size=32,
+        patch_size=2,
+        in_channels=4,
+        dim=1152,
+        depth=28,
+        num_heads=16,
+        mlp_ratio=4.0,
+        num_register_tokens=4,
+        num_classes=1000,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = in_channels
+        self.patch_size = patch_size
+        self.num_heads = num_heads
+        self.num_classes = num_classes
+
+        self.x_embedder = PatchEmbed1D(input_size, patch_size, in_channels, dim)
+        self.t_embedder = TimestepEmbedder(dim)
+        self.r_embedder = TimestepEmbedder(dim)
+
+        self.use_cond = num_classes is not None
+        self.y_embedder = LabelEmbedder(num_classes, dim) if self.use_cond else None
+
+        num_patches = self.x_embedder.num_patches
+        # Will use fixed sin-cos embedding:
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches, dim), requires_grad=True)
+
+        self.blocks = nn.ModuleList([
+            DiTBlock(dim, num_heads, mlp_ratio) for _ in range(depth)
+        ])
+        self.final_layer = FinalLayer(dim, patch_size, self.out_channels)
+
+        self.initialize_weights()
+
+    def initialize_weights(self):
+        # Initialize transformer layers:
+        def _basic_init(module):
+            if isinstance(module, nn.Linear):
+                torch.nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+        self.apply(_basic_init)
+
+        # Initialize (and freeze) pos_embed by sin-cos embedding:
+        pos_embed = get_1d_sincos_pos_embed(self.pos_embed.shape[-1], self.x_embedder.num_patches)
+        self.pos_embed.data.copy_(torch.from_numpy(pos_embed).float().unsqueeze(0))
+
+        # Initialize patch_embed like nn.Linear (instead of nn.Conv2d):
+        w = self.x_embedder.proj.weight.data
+        nn.init.xavier_uniform_(w.view([w.shape[0], -1]))
+        nn.init.constant_(self.x_embedder.proj.bias, 0)
+
+        # Initialize label embedding table:
+        if self.y_embedder is not None:
+            nn.init.normal_(self.y_embedder.embedding.weight, std=0.02)
+
+        # Initialize timestep embedding MLP:
+        nn.init.normal_(self.t_embedder.mlp[0].weight, std=0.02)
+        nn.init.normal_(self.t_embedder.mlp[2].weight, std=0.02)
+
+        # Zero-out adaLN modulation layers in DiT blocks:
+        for block in self.blocks:
+            nn.init.constant_(block.adaLN_modulation[-1].weight, 0)
+            nn.init.constant_(block.adaLN_modulation[-1].bias, 0)
+
+        # Zero-out output layers:
+        nn.init.constant_(self.final_layer.adaLN_modulation[-1].weight, 0)
+        nn.init.constant_(self.final_layer.adaLN_modulation[-1].bias, 0)
+        nn.init.constant_(self.final_layer.linear.weight, 0)
+        nn.init.constant_(self.final_layer.linear.bias, 0)
+
+    def unpatchify(self, x):
+        """Recover sequence from patches."""
+        c = self.out_channels
+        p = self.patch_size
+        L = x.shape[1] * p
+
+        x = x.reshape(x.shape[0], x.shape[1], p, c)
+        x = x.permute(0, 3, 1, 2).contiguous()
+        x = x.view(x.shape[0], c, L)
+        return x
+
+    def forward(self, x, t, r, y=None):
+        """Forward pass for 1D signals.
+
+        Args:
+            x: (N, C, L) input sequence
+            t: (N,) diffusion timestep
+            r: (N,) reference timestep
+            y: optional class labels
+        """
+
+        x = self.x_embedder(x) + self.pos_embed  # (N, T, D), T = L / patch_size
+
+        t = self.t_embedder(t)                   # (N, D)
+        r = self.r_embedder(r)
+        # t = torch.cat([t, r], dim=-1)
+        t = t + r
+
+        # condition
+        c = t
+        if self.use_cond:
+            y = self.y_embedder(y)               # (N, D)
+            c = c + y                                # (N, D)
+
+        for i, block in enumerate(self.blocks):
+            x = block(x, c)                      # (N, T, D)
+
+        x = self.final_layer(x, c)                # (N, T, patch_size * out_channels)
+        x = self.unpatchify(x)                   # (N, out_channels, L)
+        return x
+
+
+# Positional embedding from:
+# https://github.com/facebookresearch/mae/blob/main/util/pos_embed.py
+
+def get_2d_sincos_pos_embed(embed_dim, grid_size, cls_token=False, extra_tokens=0):
+    """
+    grid_size: int of the grid height and width
+    return:
+    pos_embed: [grid_size*grid_size, embed_dim] or [1+grid_size*grid_size, embed_dim] (w/ or w/o cls_token)
+    """
+    grid_h = np.arange(grid_size, dtype=np.float32)
+    grid_w = np.arange(grid_size, dtype=np.float32)
+    grid = np.meshgrid(grid_w, grid_h)  # here w goes first
+    grid = np.stack(grid, axis=0)
+
+    grid = grid.reshape([2, 1, grid_size, grid_size])
+    pos_embed = get_2d_sincos_pos_embed_from_grid(embed_dim, grid)
+    if cls_token and extra_tokens > 0:
+        pos_embed = np.concatenate([np.zeros([extra_tokens, embed_dim]), pos_embed], axis=0)
+    return pos_embed
+
+
+def get_2d_sincos_pos_embed_from_grid(embed_dim, grid):
+    assert embed_dim % 2 == 0
+
+    # use half of dimensions to encode grid_h
+    emb_h = get_1d_sincos_pos_embed_from_grid(embed_dim // 2, grid[0])  # (H*W, D/2)
+    emb_w = get_1d_sincos_pos_embed_from_grid(embed_dim // 2, grid[1])  # (H*W, D/2)
+
+    emb = np.concatenate([emb_h, emb_w], axis=1) # (H*W, D)
+    return emb
+
+
+def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
+    """
+    embed_dim: output dimension for each position
+    pos: a list of positions to be encoded: size (M,)
+    out: (M, D)
+    """
+    assert embed_dim % 2 == 0
+    omega = np.arange(embed_dim // 2, dtype=np.float64)
+    omega /= embed_dim / 2.
+    omega = 1. / 10000**omega  # (D/2,)
+
+    pos = pos.reshape(-1)  # (M,)
+    out = np.einsum('m,d->md', pos, omega)  # (M, D/2), outer product
+
+    emb_sin = np.sin(out) # (M, D/2)
+    emb_cos = np.cos(out) # (M, D/2)
+
+    emb = np.concatenate([emb_sin, emb_cos], axis=1)  # (M, D)
+    return emb
+
+
+def get_1d_sincos_pos_embed(embed_dim, length, cls_token=False, extra_tokens=0):
+    """Generate 1D sine-cosine positional embeddings."""
+    position = np.arange(length, dtype=np.float32)
+    pos_embed = get_1d_sincos_pos_embed_from_grid(embed_dim, position)
+    if cls_token and extra_tokens > 0:
+        pos_embed = np.concatenate([np.zeros([extra_tokens, embed_dim]), pos_embed], axis=0)
+    return pos_embed

--- a/Vibration/train_vibration.py
+++ b/Vibration/train_vibration.py
@@ -1,0 +1,38 @@
+import torch
+from torch.utils.data import DataLoader
+from accelerate import Accelerator
+from tqdm import tqdm
+
+from harmonic_dataset import HarmonicDataset
+from model_1d import MFDiT1D
+from meanflow_1d import MeanFlow1D
+
+
+if __name__ == '__main__':
+    steps = 1000
+    batch_size = 16
+    seq_len = 1024
+
+    accelerator = Accelerator()
+
+    dataset = HarmonicDataset(num_samples=10000, seq_len=seq_len, channels=2)
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+    dataloader = iter(dataloader)
+
+    model = MFDiT1D(input_size=seq_len, patch_size=16, in_channels=2, dim=256, depth=6, num_heads=8, num_classes=None)
+    meanflow = MeanFlow1D(channels=2, signal_length=seq_len, num_classes=None)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    model, optimizer = accelerator.prepare(model, optimizer)
+
+    for step in tqdm(range(steps), desc='training'):
+        x = next(dataloader).to(accelerator.device)
+        loss, _ = meanflow.loss(model, x)
+        accelerator.backward(loss)
+        optimizer.step()
+        optimizer.zero_grad()
+
+        if (step + 1) % 200 == 0 and accelerator.is_main_process:
+            with torch.no_grad():
+                samples = meanflow.sample(model, 4, device=accelerator.device)
+                torch.save(samples.cpu(), f'samples_step_{step+1}.pt')


### PR DESCRIPTION
## Summary
- add 1D MeanFlow variant and sampling utilities
- create 1D version of DiT transformer for sequences
- provide harmonic dataset generator
- include training script for vibration signals

## Testing
- `python -m py_compile Vibration/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c96e9ac2c8323a9c72283e1b74ae3