### PR TITLE
Add vibration time-series example

### DIFF
--- a/Vibration/harmonic_dataset.py
+++ b/Vibration/harmonic_dataset.py
@@ -1,0 +1,27 @@
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+class HarmonicDataset(Dataset):
+    """Dataset generating multi-dimensional harmonic time series."""
+    def __init__(self, length=512, channels=2, num_samples=10000, num_components=3,
+                 freq_range=(1.0, 20.0)):
+        self.length = length
+        self.channels = channels
+        self.num_samples = num_samples
+        self.num_components = num_components
+        self.freq_range = freq_range
+        self.t = np.linspace(0, 1, length, endpoint=False)
+
+    def __len__(self):
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        signal = np.zeros((self.channels, self.length), dtype=np.float32)
+        for c in range(self.channels):
+            for _ in range(self.num_components):
+                freq = np.random.uniform(*self.freq_range)
+                amp = np.random.uniform(0.5, 1.0)
+                phase = np.random.uniform(0, 2 * np.pi)
+                signal[c] += amp * np.sin(2 * np.pi * freq * self.t + phase)
+        return torch.from_numpy(signal)

--- a/Vibration/meanflow_time.py
+++ b/Vibration/meanflow_time.py
@@ -1,0 +1,165 @@
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from functools import partial
+import numpy as np
+
+
+class Normalizer:
+    """Simple normalization for time series."""
+    def __init__(self, mode='minmax', mean=None, std=None):
+        assert mode in ['minmax', 'mean_std'], "mode must be 'minmax' or 'mean_std'"
+        self.mode = mode
+        if mode == 'mean_std':
+            if mean is None or std is None:
+                raise ValueError('mean and std must be provided for mean_std mode')
+            self.mean = torch.tensor(mean).view(-1, 1)
+            self.std = torch.tensor(std).view(-1, 1)
+
+    @classmethod
+    def from_list(cls, config):
+        mode, mean, std = config
+        return cls(mode, mean, std)
+
+    def norm(self, x):
+        if self.mode == 'minmax':
+            return x * 2 - 1
+        elif self.mode == 'mean_std':
+            return (x - self.mean.to(x.device)) / self.std.to(x.device)
+
+    def unnorm(self, x):
+        if self.mode == 'minmax':
+            x = x.clip(-1, 1)
+            return (x + 1) * 0.5
+        elif self.mode == 'mean_std':
+            return x * self.std.to(x.device) + self.mean.to(x.device)
+
+
+def stopgrad(x):
+    return x.detach()
+
+
+def adaptive_l2_loss(error, gamma=0.5, c=1e-3):
+    dims = tuple(range(1, error.dim()))
+    delta_sq = torch.mean(error ** 2, dim=dims, keepdim=False)
+    p = 1.0 - gamma
+    w = 1.0 / (delta_sq + c).pow(p)
+    loss = delta_sq
+    return (stopgrad(w) * loss).mean()
+
+
+class TimeMeanFlow:
+    """MeanFlow adapted for 1D time series."""
+    def __init__(
+        self,
+        channels=2,
+        length=512,
+        num_classes=None,
+        normalizer=['minmax', None, None],
+        flow_ratio=0.50,
+        time_dist=['lognorm', -0.4, 1.0],
+        cfg_ratio=None,
+        cfg_scale=None,
+        cfg_uncond='u',
+        jvp_api='autograd',
+    ):
+        super().__init__()
+        self.channels = channels
+        self.length = length
+        self.num_classes = num_classes
+        self.use_cond = num_classes is not None
+
+        self.normer = Normalizer.from_list(normalizer)
+
+        self.flow_ratio = flow_ratio
+        self.time_dist = time_dist
+        self.cfg_ratio = cfg_ratio
+        self.w = cfg_scale
+
+        self.cfg_uncond = cfg_uncond
+        self.jvp_api = jvp_api
+
+        assert jvp_api in ['funtorch', 'autograd']
+        if jvp_api == 'funtorch':
+            self.jvp_fn = torch.func.jvp
+            self.create_graph = False
+        else:
+            self.jvp_fn = torch.autograd.functional.jvp
+            self.create_graph = True
+
+    def sample_t_r(self, batch_size, device):
+        if self.time_dist[0] == 'uniform':
+            samples = np.random.rand(batch_size, 2).astype(np.float32)
+        else:
+            mu, sigma = self.time_dist[-2], self.time_dist[-1]
+            normal_samples = np.random.randn(batch_size, 2).astype(np.float32) * sigma + mu
+            samples = 1 / (1 + np.exp(-normal_samples))
+        t_np = np.maximum(samples[:, 0], samples[:, 1])
+        r_np = np.minimum(samples[:, 0], samples[:, 1])
+        num_selected = int(self.flow_ratio * batch_size)
+        indices = np.random.permutation(batch_size)[:num_selected]
+        r_np[indices] = t_np[indices]
+        t = torch.tensor(t_np, device=device)
+        r = torch.tensor(r_np, device=device)
+        return t, r
+
+    def _expand_ts(self, t, x):
+        shape = [t.shape[0]] + [1] * (x.dim() - 1)
+        return t.view(*shape)
+
+    def loss(self, model, x, c=None):
+        batch_size = x.shape[0]
+        device = x.device
+        t, r = self.sample_t_r(batch_size, device)
+        t_ = self._expand_ts(t, x)
+        r_ = self._expand_ts(r, x)
+        e = torch.randn_like(x)
+        x = self.normer.norm(x)
+        z = (1 - t_) * x + t_ * e
+        v = e - x
+        if c is not None:
+            assert self.cfg_ratio is not None
+            uncond = torch.ones_like(c) * self.num_classes
+            cfg_mask = torch.rand_like(c.float()) < self.cfg_ratio
+            c = torch.where(cfg_mask, uncond, c)
+            if self.w is not None:
+                with torch.no_grad():
+                    u_t = model(z, t, t, uncond)
+                v_hat = self.w * v + (1 - self.w) * u_t
+                if self.cfg_uncond == 'v':
+                    cfg_mask = self._expand_ts(cfg_mask, x).bool()
+                    v_hat = torch.where(cfg_mask, v, v_hat)
+            else:
+                v_hat = v
+        else:
+            v_hat = v
+        model_partial = partial(model, y=c)
+        jvp_args = (
+            lambda z, t, r: model_partial(z, t, r),
+            (z, t, r),
+            (v_hat, torch.ones_like(t), torch.zeros_like(r)),
+        )
+        if self.create_graph:
+            u, dudt = self.jvp_fn(*jvp_args, create_graph=True)
+        else:
+            u, dudt = self.jvp_fn(*jvp_args)
+        u_tgt = v_hat - (t_ - r_) * dudt
+        error = u - stopgrad(u_tgt)
+        loss = adaptive_l2_loss(error)
+        mse_val = (stopgrad(error) ** 2).mean()
+        return loss, mse_val
+
+    @torch.no_grad()
+    def sample(self, model, num_samples, sample_steps=5, device='cuda'):
+        model.eval()
+        z = torch.randn(num_samples, self.channels, self.length, device=device)
+        t_vals = torch.linspace(1.0, 0.0, sample_steps + 1, device=device)
+        for i in range(sample_steps):
+            t = torch.full((z.size(0),), t_vals[i], device=device)
+            r = torch.full((z.size(0),), t_vals[i + 1], device=device)
+            t_ = self._expand_ts(t, z)
+            r_ = self._expand_ts(r, z)
+            v = model(z, t, r)
+            z = z - (t_ - r_) * v
+        z = self.normer.unnorm(z)
+        return z

--- a/Vibration/time_dit.py
+++ b/Vibration/time_dit.py
@@ -1,0 +1,211 @@
+"""Transformer model for 1D vibration signals."""
+
+import torch
+import torch.nn as nn
+import numpy as np
+import math
+from timm.models.vision_transformer import Attention
+import torch.nn.functional as F
+from einops import repeat
+
+
+def modulate(x, scale, shift):
+    return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+
+
+class TimestepEmbedder(nn.Module):
+    def __init__(self, dim, nfreq=256):
+        super().__init__()
+        self.mlp = nn.Sequential(nn.Linear(nfreq, dim), nn.SiLU(), nn.Linear(dim, dim))
+        self.nfreq = nfreq
+
+    @staticmethod
+    def timestep_embedding(t, dim, max_period=10000):
+        half_dim = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period)
+            * torch.arange(start=0, end=half_dim, dtype=torch.float32)
+            / half_dim
+        ).to(device=t.device)
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])], dim=-1
+            )
+        return embedding
+
+    def forward(self, t):
+        t = t * 1000
+        t_freq = self.timestep_embedding(t, self.nfreq)
+        t_emb = self.mlp(t_freq)
+        return t_emb
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.scale = dim ** 0.5
+        self.g = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        return F.normalize(x, dim=-1) * self.scale * self.g
+
+
+class TimePatchEmbed(nn.Module):
+    def __init__(self, length, patch_size, in_channels, dim):
+        super().__init__()
+        self.proj = nn.Conv1d(in_channels, dim, kernel_size=patch_size, stride=patch_size)
+        self.num_patches = length // patch_size
+        self.patch_size = patch_size
+
+    def forward(self, x):
+        # x: (N, C, L)
+        x = self.proj(x)
+        x = x.transpose(1, 2)
+        return x
+
+
+class Mlp(nn.Module):
+    def __init__(self, in_features, hidden_features):
+        super().__init__()
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(hidden_features, in_features)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.fc2(x)
+        return x
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim, num_heads, mlp_ratio=4.0):
+        super().__init__()
+        self.norm1 = RMSNorm(dim)
+        self.attn = Attention(dim, num_heads=num_heads, qkv_bias=True, qk_norm=True, norm_layer=RMSNorm)
+        self.attn.fused_attn = False
+        self.norm2 = RMSNorm(dim)
+        mlp_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_dim)
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(dim, 6 * dim))
+
+    def forward(self, x, c):
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            self.adaLN_modulation(c).chunk(6, dim=-1)
+        )
+        x = x + gate_msa.unsqueeze(1) * self.attn(
+            modulate(self.norm1(x), scale_msa, shift_msa)
+        )
+        x = x + gate_mlp.unsqueeze(1) * self.mlp(
+            modulate(self.norm2(x), scale_mlp, shift_mlp)
+        )
+        return x
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, dim, patch_size, out_dim):
+        super().__init__()
+        self.norm_final = RMSNorm(dim)
+        self.linear = nn.Linear(dim, patch_size * out_dim)
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(dim, 2 * dim))
+        self.patch_size = patch_size
+        self.out_dim = out_dim
+
+    def forward(self, x, c):
+        shift, scale = self.adaLN_modulation(c).chunk(2, dim=-1)
+        x = modulate(self.norm_final(x), shift, scale)
+        x = self.linear(x)
+        return x
+
+
+class TimeDiT(nn.Module):
+    def __init__(
+        self,
+        input_size=512,
+        patch_size=1,
+        in_channels=2,
+        dim=256,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        num_classes=None,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = in_channels
+        self.patch_size = patch_size
+        self.num_heads = num_heads
+        self.num_classes = num_classes
+
+        self.x_embedder = TimePatchEmbed(input_size, patch_size, in_channels, dim)
+        self.t_embedder = TimestepEmbedder(dim)
+        self.r_embedder = TimestepEmbedder(dim)
+
+        self.use_cond = num_classes is not None
+        self.y_embedder = nn.Embedding(num_classes + 1, dim) if self.use_cond else None
+
+        num_patches = self.x_embedder.num_patches
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches, dim), requires_grad=True)
+
+        self.blocks = nn.ModuleList([
+            DiTBlock(dim, num_heads, mlp_ratio) for _ in range(depth)
+        ])
+        self.final_layer = FinalLayer(dim, patch_size, self.out_channels)
+
+        self.initialize_weights()
+
+    def initialize_weights(self):
+        def _basic_init(module):
+            if isinstance(module, nn.Linear):
+                torch.nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+        self.apply(_basic_init)
+        nn.init.normal_(self.pos_embed, std=0.02)
+        if self.y_embedder is not None:
+            nn.init.normal_(self.y_embedder.weight, std=0.02)
+        for block in self.blocks:
+            nn.init.constant_(block.adaLN_modulation[-1].weight, 0)
+            nn.init.constant_(block.adaLN_modulation[-1].bias, 0)
+        nn.init.constant_(self.final_layer.adaLN_modulation[-1].weight, 0)
+        nn.init.constant_(self.final_layer.adaLN_modulation[-1].bias, 0)
+        nn.init.constant_(self.final_layer.linear.weight, 0)
+        nn.init.constant_(self.final_layer.linear.bias, 0)
+
+    def unpatchify(self, x):
+        c = self.out_channels
+        p = self.patch_size
+        l = x.shape[1]
+        x = x.view(x.shape[0], l, p, c)
+        x = x.permute(0, 3, 1, 2).reshape(x.shape[0], c, l * p)
+        return x
+
+    def forward(self, x, t, r, y=None):
+        l = x.shape[-1]
+        x = self.x_embedder(x) + self.pos_embed
+        t = self.t_embedder(t)
+        r = self.r_embedder(r)
+        c = t + r
+        if self.use_cond:
+            y = self.y_embedder(y)
+            c = c + y
+        for block in self.blocks:
+            x = block(x, c)
+        x = self.final_layer(x, c)
+        x = self.unpatchify(x)
+        return x
+
+
+def get_1d_sincos_pos_embed(embed_dim, pos):
+    assert embed_dim % 2 == 0
+    omega = np.arange(embed_dim // 2, dtype=np.float64)
+    omega /= embed_dim / 2.
+    omega = 1. / 10000**omega
+    pos = pos.reshape(-1)
+    out = np.einsum('m,d->md', pos, omega)
+    emb_sin = np.sin(out)
+    emb_cos = np.cos(out)
+    emb = np.concatenate([emb_sin, emb_cos], axis=1)
+    return emb

--- a/Vibration/train_vibration.py
+++ b/Vibration/train_vibration.py
@@ -1,0 +1,46 @@
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from harmonic_dataset import HarmonicDataset
+from time_dit import TimeDiT
+from meanflow_time import TimeMeanFlow
+
+
+def main():
+    length = 512
+    channels = 2
+    batch_size = 32
+    steps = 1000
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+    dataset = HarmonicDataset(length=length, channels=channels, num_samples=10000)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+    loader_iter = iter(loader)
+
+    model = TimeDiT(input_size=length, patch_size=1, in_channels=channels,
+                    dim=256, depth=6, num_heads=8, num_classes=None).to(device)
+    meanflow = TimeMeanFlow(channels=channels, length=length, num_classes=None)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    pbar = tqdm(range(steps))
+    for step in pbar:
+        try:
+            x = next(loader_iter)
+        except StopIteration:
+            loader_iter = iter(loader)
+            x = next(loader_iter)
+        x = x.to(device)
+        loss, _ = meanflow.loss(model, x)
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        pbar.set_description(f"loss: {loss.item():.4f}")
+
+    torch.save(model.state_dict(), 'vibration_model.pt')
+    samples = meanflow.sample(model, num_samples=4, device=device)
+    torch.save(samples.cpu(), 'vibration_samples.pt')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement dataset `HarmonicDataset` for synthetic harmonic signals
- port MeanFlow to 1D time series in `TimeMeanFlow`
- implement transformer model `TimeDiT` for sequence data
- add training script `train_vibration.py`

## Testing
- `python -m py_compile Vibration/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c96e9ac2c8323a9c72283e1b74ae3